### PR TITLE
fix(letter): use correct LCO option 'SN' for sn-right standard

### DIFF
--- a/src/texsmith/templates/letter/__init__.py
+++ b/src/texsmith/templates/letter/__init__.py
@@ -61,14 +61,14 @@ _LETTER_STANDARD_ALIASES: dict[str, str] = {
     "din-5008": "din",
     "de": "din",
     "german": "din",
-    "sn": "sn-left",
+    "sn": "sn-right",
     "sn010130": "sn-left",
     "sn-010130": "sn-left",
     "snleft": "sn-left",
     "sn-left": "sn-left",
     "snright": "sn-right",
     "sn-right": "sn-right",
-    "swiss": "sn-left",
+    "swiss": "sn-right",
     "nf": "nf",
 }
 

--- a/src/texsmith/templates/letter/__init__.py
+++ b/src/texsmith/templates/letter/__init__.py
@@ -51,7 +51,7 @@ class LetterStandard:
 _LETTER_STANDARDS: dict[str, LetterStandard] = {
     "din": LetterStandard(key="din", option="DIN"),
     "sn-left": LetterStandard(key="sn-left", option="SNleft"),
-    "sn-right": LetterStandard(key="sn-right", option="SNright"),
+    "sn-right": LetterStandard(key="sn-right", option="SN"),
     "nf": LetterStandard(key="nf", option="NF"),
 }
 

--- a/tests/test_letter_template.py
+++ b/tests/test_letter_template.py
@@ -52,7 +52,7 @@ def test_letter_template_accepts_standard_override() -> None:
     )
 
     assert context["letter_standard"] == "sn-right"
-    assert context["letter_standard_option"] == "SNright"
+    assert context["letter_standard_option"] == "SN"
 
 
 def test_letter_template_supports_nf_format_alias() -> None:

--- a/tests/test_template_attributes.py
+++ b/tests/test_template_attributes.py
@@ -247,8 +247,8 @@ def test_letter_template_prefers_direct_format_override() -> None:
 
     context = template.prepare_context("Body", overrides=overrides)
 
-    assert context["letter_standard"] == "sn-left"
-    assert context["letter_standard_option"] == "SNleft"
+    assert context["letter_standard"] == "sn-right"
+    assert context["letter_standard_option"] == "SN"
 
 
 def test_book_template_supports_columns_option() -> None:


### PR DESCRIPTION
The sn-right layout was mapped to the LCO option SNright, which does not exist in KOMA-Script's scrlttr2. The correct file is SN (address window on the right per Swiss norm). 
https://komascript.de/files/KOMA%20cha%2004.pdf 