### PR TITLE
feat: template-scoped render extensions (custom @reads/@writes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
 and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Template-scoped render extensions.** A template's `[latex.template]` manifest section can now declare `readers` (a list of importable modules whose `@reads` HTML→IR lowerings are layered on top of the bundled registry) and `writer` (a `"module:Class"` reference to a `LaTeXWriter` subclass adding or overriding `@writes` emitters). They are resolved when the template is selected and applied to the `LaTeXRenderer` **for that template only**, so a template package (exam, thesis, poster…) can own custom constructs without affecting other templates' conversions. This restores third-party custom rendering after the 0.4.0 IR migration removed the global `@renders` / `texsmith.renderers` mechanism; the new hook is deliberately template-scoped (no global reader/writer registration). New public helper `texsmith.readers.html.build_reader_registry(extra_modules=…)`; resolution lives in `texsmith.core.templates.extensions`. Documented in `docs/api/handlers.md`.
+
 ## [0.4.0] - 2026-06-27
 
 ### Added

--- a/docs/api/handlers.md
+++ b/docs/api/handlers.md
@@ -60,6 +60,52 @@ for a complete, runnable extension wiring both halves into a `LaTeXRenderer`.
     `attrs` (e.g. `("role", "counter")`) rather than backend strings. Only the
     writer knows about LaTeX.
 
+## Shipping readers & writers in a template
+
+When custom constructs belong to a specific **template** (an exam, a thesis, a
+poster…), declare the reader modules and the writer subclass in that template's
+`[latex.template]` manifest section. TeXSmith resolves them when the template is
+selected and applies them to the renderer **for that template only** — other
+templates keep the default bundled read→write path.
+
+```toml
+[latex.template]
+name = "exam"
+version = "1.0.0"
+entrypoint = "template/template.tex"
+engine = "lualatex"
+
+# Modules whose @reads lowerings are layered on top of the bundled registry.
+# A higher-priority handler may return NotHandled to fall through to a core one.
+readers = ["my_exam_pkg.reader"]
+
+# A "module:Class" reference to a LaTeXWriter subclass adding/overriding @writes.
+writer = "my_exam_pkg.writer:ExamLaTeXWriter"
+```
+
+- **`readers`** — a list of importable module paths. Every `@reads`-decorated
+  callable found in each module is registered, layered on top of the bundled
+  HTML→IR lowerings (`texsmith.readers.html.build_reader_registry`).
+- **`writer`** — a `"module:Class"` reference to a `LaTeXWriter` subclass. It is
+  validated at render time (must subclass `LaTeXWriter`), then used as the
+  template's writer so its `@writes` emitters and overrides take effect.
+
+Both are resolved with the same import machinery as attribute normalisers and
+fragment entrypoints, so a typo or a bad reference fails early with an
+actionable `TemplateError`. A template that declares neither is unaffected.
+
+!!! note "Scope"
+    These hooks are **template-scoped by design**. Because exam-style rules
+    (e.g. mapping every `h1` to `\question`) would corrupt unrelated documents,
+    they are never registered globally — only while the declaring template
+    renders. There is no global reader/writer entry point.
+
+Inside an extension, read template front-matter overrides from
+`self.state.runtime["template_overrides"]` (already populated by the pipeline);
+keep cross-node state on `self.state.state` (the `DocumentState`) and harvest it
+in a pre-pass over the IR (`texsmith.ir.visitor.walk`) rather than mutating
+shared state during emission.
+
 ## Reference
 
 ::: texsmith.readers.html.registry

--- a/src/texsmith/core/conversion/core.py
+++ b/src/texsmith/core/conversion/core.py
@@ -488,6 +488,27 @@ def _build_runtime_common(
     return runtime_common
 
 
+def _apply_template_render_extensions(
+    renderer: LaTeXRenderer, binding: TemplateBinding
+) -> None:
+    """Wire a selected template's custom ``@reads``/``@writes`` into ``renderer``.
+
+    Reads the ``readers`` / ``writer`` hooks forwarded onto the binding's runtime
+    extras and applies them to the renderer's reader-registry / writer-class
+    seams. Scoped to this template; a no-op when none are declared.
+    """
+    runtime = binding.runtime
+    if runtime is None:
+        return
+    readers = runtime.extras.get("readers") or []
+    writer = runtime.extras.get("writer")
+    if not readers and not writer:
+        return
+    from texsmith.core.templates.extensions import apply_render_extensions
+
+    apply_render_extensions(renderer, readers=readers, writer=writer)
+
+
 def _render_slot_fragments(
     *,
     slot_fragments: list[SlotFragment],
@@ -555,6 +576,7 @@ def _render_slot_fragments(
                 formatter=formatter,
                 **renderer_kwargs,
             )
+            _apply_template_render_extensions(renderer, binding)
         return renderer
 
     slot_outputs: dict[str, str] = {}

--- a/src/texsmith/core/conversion/core.py
+++ b/src/texsmith/core/conversion/core.py
@@ -488,9 +488,7 @@ def _build_runtime_common(
     return runtime_common
 
 
-def _apply_template_render_extensions(
-    renderer: LaTeXRenderer, binding: TemplateBinding
-) -> None:
+def _apply_template_render_extensions(renderer: LaTeXRenderer, binding: TemplateBinding) -> None:
     """Wire a selected template's custom ``@reads``/``@writes`` into ``renderer``.
 
     Reads the ``readers`` / ``writer`` hooks forwarded onto the binding's runtime

--- a/src/texsmith/core/templates/extensions.py
+++ b/src/texsmith/core/templates/extensions.py
@@ -1,0 +1,86 @@
+"""Resolve a template's render-extension hooks (custom readers / writer).
+
+A template package can extend the LaTeX conversion pipeline for *its own*
+documents by declaring, in its ``[latex.template]`` manifest section:
+
+* ``readers`` — a list of importable module paths whose ``@reads`` lowerings are
+  layered on top of the bundled HTML→IR registry;
+* ``writer`` — a ``"module:Class"`` reference to a :class:`LaTeXWriter` subclass
+  that adds or overrides ``@writes`` emitters.
+
+These hooks are **scoped to the selected template**: they are applied to the
+``LaTeXRenderer`` only while that template is rendering, so installing an
+exam/thesis/… template never changes how other templates convert.
+
+The resolution reuses the same ``"module:attribute"`` import machinery as
+attribute normalisers and fragment entrypoints, so misconfiguration fails early
+with an actionable :class:`TemplateError`.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from .manifest import TemplateError, _import_object
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from texsmith.adapters.latex.renderer import LaTeXRenderer
+    from texsmith.writers.latex.writer import LaTeXWriter
+
+
+def resolve_reader_modules(paths: Iterable[str]) -> list[object]:
+    """Import each module path, raising ``TemplateError`` on failure."""
+    modules: list[object] = []
+    for path in paths:
+        if not isinstance(path, str) or not path.strip():
+            raise TemplateError(f"Invalid template reader module reference: {path!r}.")
+        try:
+            modules.append(import_module(path.strip()))
+        except ImportError as exc:
+            raise TemplateError(
+                f"Template reader module '{path}' could not be imported: {exc}."
+            ) from exc
+    return modules
+
+
+def resolve_writer_class(reference: str) -> type[LaTeXWriter]:
+    """Import and validate a ``"module:Class"`` LaTeXWriter subclass reference."""
+    from texsmith.writers.latex.writer import LaTeXWriter
+
+    obj = _import_object(reference, allow_dotted=True)
+    if not (isinstance(obj, type) and issubclass(obj, LaTeXWriter)):
+        raise TemplateError(
+            f"Template writer '{reference}' must resolve to a LaTeXWriter subclass, "
+            f"got {obj!r}."
+        )
+    return obj
+
+
+def apply_render_extensions(
+    renderer: LaTeXRenderer,
+    *,
+    readers: Sequence[str] | None,
+    writer: str | None,
+) -> None:
+    """Populate ``renderer`` with a template's custom readers and/or writer.
+
+    A no-op when the template declares neither, keeping the default
+    bundled-only read→write path untouched.
+    """
+    if readers:
+        from texsmith.readers.html import build_reader_registry
+
+        renderer.reader_registry = build_reader_registry(resolve_reader_modules(readers))
+    if writer:
+        renderer.writer_class = resolve_writer_class(writer)
+
+
+__all__ = [
+    "apply_render_extensions",
+    "resolve_reader_modules",
+    "resolve_writer_class",
+]

--- a/src/texsmith/core/templates/manifest.py
+++ b/src/texsmith/core/templates/manifest.py
@@ -733,6 +733,14 @@ class TemplateInfo(BaseModel):
     texlive_year: int | None = None
     tlmgr_packages: list[str] = Field(default_factory=list)
     fragments: list[str] | None = None
+    # Render-extension hooks (resolved when this template is selected):
+    # ``readers`` lists importable modules whose ``@reads`` lowerings are layered
+    # on top of the bundled HTML→IR registry; ``writer`` is a ``"module:Class"``
+    # reference to a ``LaTeXWriter`` subclass adding/overriding ``@writes``
+    # emitters. Both are scoped to this template — they never affect other
+    # templates' conversions.
+    readers: list[str] = Field(default_factory=list)
+    writer: str | None = None
     markdown_extensions: list[str] = Field(default_factory=list)
     override: list[str] = Field(default_factory=list)
     required_partials: list[str] = Field(default_factory=list)

--- a/src/texsmith/core/templates/runtime.py
+++ b/src/texsmith/core/templates/runtime.py
@@ -245,6 +245,8 @@ def load_template_runtime(template: str) -> TemplateRuntime:
         "fragments",
         declared_fragments if declared_fragments is not None else [],
     )
+    extras.setdefault("readers", list(template_instance.info.readers or []))
+    extras.setdefault("writer", template_instance.info.writer)
 
     return TemplateRuntime(
         instance=template_instance,

--- a/src/texsmith/readers/html/__init__.py
+++ b/src/texsmith/readers/html/__init__.py
@@ -13,7 +13,7 @@ The reader produces a pure, backend-agnostic IR tree and never emits LaTeX.
 from __future__ import annotations
 
 from .context import ReadContext
-from .reader import HtmlReader
+from .reader import HtmlReader, build_reader_registry
 from .registry import NotHandled, ReaderRegistry, ReaderRule, ReadLevel, reads
 
 
@@ -24,5 +24,6 @@ __all__ = [
     "ReadLevel",
     "ReaderRegistry",
     "ReaderRule",
+    "build_reader_registry",
     "reads",
 ]

--- a/src/texsmith/readers/html/reader.py
+++ b/src/texsmith/readers/html/reader.py
@@ -104,12 +104,25 @@ _BLOCK_TAGS: frozenset[str] = frozenset(
 _INLINE_TAGS: frozenset[str] = frozenset({"img", "script", "ts-marginnote"})
 
 
-def _build_registry() -> ReaderRegistry:
-    """Assemble the default registry from the lowering modules."""
+def build_reader_registry(extra_modules: Iterable[object] = ()) -> ReaderRegistry:
+    """Assemble a registry from the bundled lowering modules plus ``extra_modules``.
+
+    The bundled modules are collected first; any ``extra_modules`` (e.g. a
+    template's ``@reads`` module) are layered on top. Because
+    :meth:`ReaderRegistry.candidates` orders by descending priority (stable on
+    registration order), an extra handler declaring a higher ``priority`` than a
+    bundled one for the same tag is tried first and may return ``NotHandled`` to
+    fall through to the bundled handler.
+    """
     registry = ReaderRegistry()
-    for module in (_inline, _blocks, _extensions):
+    for module in (_inline, _blocks, _extensions, *extra_modules):
         registry.collect_from(module)
     return registry
+
+
+def _build_registry() -> ReaderRegistry:
+    """Assemble the default registry from the bundled lowering modules."""
+    return build_reader_registry()
 
 
 class HtmlReader:

--- a/tests/test_template_render_extensions.py
+++ b/tests/test_template_render_extensions.py
@@ -1,0 +1,145 @@
+"""Tests for template-scoped render extensions (custom @reads / @writes)."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from texsmith.adapters.latex.renderer import LaTeXRenderer
+from texsmith.core.conversion.core import _apply_template_render_extensions
+from texsmith.core.templates.extensions import (
+    apply_render_extensions,
+    resolve_reader_modules,
+    resolve_writer_class,
+)
+from texsmith.core.templates.manifest import TemplateError, TemplateInfo
+from texsmith.ir import nodes as ir
+from texsmith.readers.html import build_reader_registry
+from texsmith.readers.html.registry import ReadLevel, reads
+from texsmith.writers.latex.writer import LaTeXWriter
+from texsmith.writers.registry import writes
+
+
+def _custom_reader_module() -> types.ModuleType:
+    """A throwaway module exposing one @reads lowering for <blink>."""
+    module = types.ModuleType("exam_test_reader")
+
+    @reads("blink", level=ReadLevel.INLINE, priority=200, name="t_blink")
+    def read_blink(tag, ctx):
+        return ir.RawInline("latex", r"\BLINK")
+
+    module.read_blink = read_blink
+    return module
+
+
+class _UpperWriter(LaTeXWriter):
+    """A LaTeXWriter subclass that upper-cases plain text."""
+
+    @writes(ir.Str)
+    def _str(self, node: ir.Str) -> str:
+        return node.text.upper()
+
+
+# -- manifest parsing ------------------------------------------------------
+
+
+def test_template_info_parses_readers_and_writer() -> None:
+    info = TemplateInfo(
+        name="exam",
+        version="1.0",
+        readers=["pkg.reader_a", "pkg.reader_b"],
+        writer="pkg.writer:ExamWriter",
+    )
+    assert info.readers == ["pkg.reader_a", "pkg.reader_b"]
+    assert info.writer == "pkg.writer:ExamWriter"
+
+
+def test_template_info_defaults_have_no_extensions() -> None:
+    info = TemplateInfo(name="plain", version="1.0")
+    assert info.readers == []
+    assert info.writer is None
+
+
+# -- resolution ------------------------------------------------------------
+
+
+def test_resolve_reader_modules_imports_real_modules() -> None:
+    modules = resolve_reader_modules(["texsmith.readers.html.blocks"])
+    assert len(modules) == 1
+    assert modules[0].__name__ == "texsmith.readers.html.blocks"
+
+
+def test_resolve_reader_modules_bad_path_raises() -> None:
+    with pytest.raises(TemplateError, match="could not be imported"):
+        resolve_reader_modules(["texsmith.does_not_exist_xyz"])
+
+
+def test_resolve_writer_class_accepts_subclass() -> None:
+    cls = resolve_writer_class("texsmith.writers.latex.writer:LaTeXWriter")
+    assert cls is LaTeXWriter
+
+
+def test_resolve_writer_class_rejects_non_writer() -> None:
+    with pytest.raises(TemplateError, match="must resolve to a LaTeXWriter subclass"):
+        resolve_writer_class("builtins:dict")
+
+
+# -- the renderer seams actually change output -----------------------------
+
+
+def test_custom_reader_changes_output() -> None:
+    renderer = LaTeXRenderer()
+    renderer.reader_registry = build_reader_registry([_custom_reader_module()])
+    out = renderer.render("<p>before <blink>x</blink> after</p>")
+    assert r"\BLINK" in out
+
+
+def test_custom_writer_changes_output() -> None:
+    renderer = LaTeXRenderer()
+    renderer.writer_class = _UpperWriter
+    out = renderer.render("<p>hello world</p>")
+    assert "HELLO WORLD" in out
+
+
+# -- apply_render_extensions glue -----------------------------------------
+
+
+def test_apply_render_extensions_sets_both_seams() -> None:
+    renderer = LaTeXRenderer()
+    apply_render_extensions(
+        renderer,
+        readers=["texsmith.readers.html.blocks"],
+        writer="texsmith.writers.latex.writer:LaTeXWriter",
+    )
+    assert renderer.reader_registry is not None
+    assert renderer.writer_class is LaTeXWriter
+
+
+def test_apply_render_extensions_noop_when_empty() -> None:
+    renderer = LaTeXRenderer()
+    apply_render_extensions(renderer, readers=None, writer=None)
+    assert renderer.reader_registry is None
+    assert renderer.writer_class is LaTeXWriter
+
+
+# -- core.py binding glue --------------------------------------------------
+
+
+def test_apply_template_render_extensions_reads_binding_extras() -> None:
+    renderer = LaTeXRenderer()
+
+    runtime = types.SimpleNamespace(
+        extras={"writer": "texsmith.writers.latex.writer:LaTeXWriter", "readers": []}
+    )
+    binding = types.SimpleNamespace(runtime=runtime)
+
+    _apply_template_render_extensions(renderer, binding)  # type: ignore[arg-type]
+    assert renderer.writer_class is LaTeXWriter
+
+
+def test_apply_template_render_extensions_noop_without_runtime() -> None:
+    renderer = LaTeXRenderer()
+    binding = types.SimpleNamespace(runtime=None)
+    _apply_template_render_extensions(renderer, binding)  # type: ignore[arg-type]
+    assert renderer.reader_registry is None


### PR DESCRIPTION
## Summary

Restores third-party custom rendering after the v0.4.0 IR migration removed the global `@renders` / `texsmith.renderers` mechanism. A template can now declare its own HTML→IR lowerings and IR→LaTeX emitters, **scoped to that template**.

## What's in here

A template's `[latex.template]` manifest section gains two keys:

- **`readers`** — a list of importable module paths whose `@reads` lowerings are layered on top of the bundled HTML→IR registry (`build_reader_registry`).
- **`writer`** — a `"module:Class"` reference to a `LaTeXWriter` subclass adding/overriding `@writes` emitters.

They are resolved when the template is selected and applied to the `LaTeXRenderer` **only while that template renders** — installing an exam/thesis/poster template never changes how other templates convert. Resolution reuses the existing `"module:attribute"` import machinery, so misconfiguration fails early with an actionable `TemplateError`.

### Why template-scoped (not a global entry point)

Exam-style rules (e.g. mapping every `h1` → `\question`) would corrupt unrelated documents if registered globally. The previous `texsmith.renderers` entry point was global; this hook is intentionally bound to the declaring template.

## Changes

- `TemplateInfo`: new `readers` / `writer` fields.
- `texsmith.readers.html.build_reader_registry(extra_modules=…)` — new public helper (bundled + extra modules).
- `texsmith.core.templates.extensions` — resolution + `apply_render_extensions`.
- `core.py`: `renderer_factory` applies the selected template's extensions.
- Docs: new "Shipping readers & writers in a template" section in `docs/api/handlers.md`.
- 12 new tests; `CHANGELOG` updated.

Note: `runtime["template_overrides"]` is already surfaced to the writer state in 0.4.0, so extensions can read front-matter overrides without any further hook.

## Verification

- `uv run pytest`: 866 passing. `ruff check .`: clean.

This unblocks migrating the `texsmith-exam` template (and similar packages) to v0.4.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)